### PR TITLE
Support Watch view for multicore debugging with amalgamator

### DIFF
--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -426,6 +426,14 @@ export class AmalgamatorSession extends LoggingDebugSession {
         response.body = variables.body;
         this.sendResponse(response);
     }
+    
+    protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
+        const [childDap, childFrameId] = this.frameHandles.get(args.frameId ? args.frameId : 0);
+        args.frameId = childFrameId;
+        const evaluate = await childDap.evaluateRequest(args);
+        response.body = evaluate.body;
+        this.sendResponse(response);
+    }
 
     protected async nextRequest(
         response: DebugProtocol.NextResponse,


### PR DESCRIPTION
Description: When debugging multicore with amalgamator, added expressions on Watch view  do not have their values shown. 

Root-cause: Amalgamator is currently not supported for expressions on Watch view.

Solution: Add the function for support evaluation expression.