### PR TITLE
Support Watch view for multicore debugging

### DIFF
--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -432,7 +432,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
         args.frameId = childFrameId;
         const timer = setTimeout(() => {
             response.body = {
-                result: 'Error: could not evalute expression',
+                result: 'Error: could not evaluate expression',
                 variablesReference: 0,
             }
             this.sendResponse(response);

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -428,7 +428,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
     }
     
     protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
-        const [childDap, childFrameId] = this.frameHandles.get(args.frameId ? args.frameId : 0);
+        const [childDap, childFrameId] = this.frameHandles.get(args.frameId);
         args.frameId = childFrameId;
         const evaluate = await childDap.evaluateRequest(args);
         response.body = evaluate.body;

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -430,7 +430,16 @@ export class AmalgamatorSession extends LoggingDebugSession {
     protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
         const [childDap, childFrameId] = this.frameHandles.get(args.frameId);
         args.frameId = childFrameId;
+        const timer = setTimeout(() => {
+            response.body = {
+                result: 'Error: could not evalute expression',
+                variablesReference: 0,
+            }
+            this.sendResponse(response);
+            clearTimeout(timer);
+        }, 100);
         const evaluate = await childDap.evaluateRequest(args);
+        clearTimeout(timer);
         response.body = evaluate.body;
         this.sendResponse(response);
     }

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -426,6 +426,14 @@ export class AmalgamatorSession extends LoggingDebugSession {
         response.body = variables.body;
         this.sendResponse(response);
     }
+    
+    protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
+        const [childDap, childFrameId] = this.frameHandles.get(args.frameId ? args.frameId : 0);
+        args.frameId = childFrameId;
+        const evaluate = await childDap.evaluateRequest(args);
+        response.body = evaluate.body;
+        this.sendResponse(response);
+    }
 
     protected async nextRequest(
         response: DebugProtocol.NextResponse,

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -435,12 +435,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
         if (args.frameId) {
             const [childDap, childFrameId] = this.frameHandles.get(args.frameId);
             args.frameId = childFrameId;
-            const timer = setTimeout(() => {
-                this.sendResponse(response);
-                clearTimeout(timer);
-            }, 100);
             const evaluate = await childDap.evaluateRequest(args);
-            clearTimeout(timer);
             response.body = evaluate.body;
         }
         this.sendResponse(response);


### PR DESCRIPTION
Description: When debugging multicore with amalgamator, added expressions on Watch view do not have their values shown.

Root-cause: Amalgamator is currently not supported for expressions on Watch view.

Solution: Add the function for support evaluation expression.