### PR TITLE
Fix bug Watch view cannot be used

### DIFF
--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -433,10 +433,14 @@ export class AmalgamatorSession extends LoggingDebugSession {
             variablesReference: 0,
         };
         if (args.frameId) {
-            const [childDap, childFrameId] = this.frameHandles.get(args.frameId);
-            args.frameId = childFrameId;
-            const evaluate = await childDap.evaluateRequest(args);
-            response.body = evaluate.body;
+            try {
+                const [childDap, childFrameId] = this.frameHandles.get(args.frameId);
+                args.frameId = childFrameId;
+                const evaluate = await childDap.evaluateRequest(args);
+                response.body = evaluate.body;
+            } catch (err) {
+                //Do nothing
+            }
         }
         this.sendResponse(response);
     }

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -428,21 +428,27 @@ export class AmalgamatorSession extends LoggingDebugSession {
     }
     
     protected async evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): Promise<void> {
-        response.body = {
-            result: 'Error: could not evaluate expression',
-            variablesReference: 0,
-        };
         if (args.frameId) {
             try {
                 const [childDap, childFrameId] = this.frameHandles.get(args.frameId);
                 args.frameId = childFrameId;
                 const evaluate = await childDap.evaluateRequest(args);
                 response.body = evaluate.body;
+                this.sendResponse(response);
             } catch (err) {
-                //Do nothing
+                this.sendErrorResponse(
+                    response,
+                    1,
+                    err instanceof Error ? err.message : String(err)
+                );
             }
+        } else {
+            this.sendErrorResponse(
+                response,
+                1,
+                'Cannot get evaluate expression'
+            );
         }
-        this.sendResponse(response);
     }
 
     protected async nextRequest(


### PR DESCRIPTION
Description: When variables are added in the Watch view before debugging,  
all sessions of debugging will send command to Server to get variable value. 
But in the session that does not have a source of file including variable, the 
error  response from Server is returned. But in amalgamator does not receive 
this event in evaluateRequest() function. That makes Watch view hangs for 
waiting response  from amalgamator, and Watch view cannot be used then.

Solution: Add exception try...catch to catch the error message return from
 server when the  command is not handled successfully. This always returns 
the response to client if error occurs.