### PR TITLE
Support disassembly view

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
     "@vscode/debugadapter": "^1.50.0",
-    "@vscode/debugadapter-testsupport": "^1.50.0",
+    "@vscode/debugadapter-testsupport": "^1.58.0-pre.0",
     "cdt-gdb-adapter": "^0.0.15-next",
     "chai": "^4.3.6",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/vscode": "^1.63.1",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
-    "@vscode/debugadapter": "^1.50.0",
+    "@vscode/debugadapter": "^1.58.0-pre.0",
     "@vscode/debugadapter-testsupport": "^1.58.0-pre.0",
     "cdt-gdb-adapter": "^0.0.15-next",
     "chai": "^4.3.6",

--- a/src/AmalgamatorClient.ts
+++ b/src/AmalgamatorClient.ts
@@ -17,7 +17,7 @@ export class AmalgamatorClient extends DebugClient {
     private clientExited = false;
     // There should not be any error output from a client - any error is probably fatal.
     private errorOutput = '';
-   
+
     public hasClientExited() {
         return this.clientExited;
     }

--- a/src/AmalgamatorClient.ts
+++ b/src/AmalgamatorClient.ts
@@ -71,4 +71,9 @@ export class AmalgamatorClient extends DebugClient {
             });
         }
     }
+    public disassembleRequest(
+        args: DebugProtocol.DisassembleArguments
+    ): Promise<DebugProtocol.DisassembleResponse> {
+        return this.send('disassemble', args);
+    }
 }

--- a/src/AmalgamatorClient.ts
+++ b/src/AmalgamatorClient.ts
@@ -15,12 +15,8 @@ import { logger } from '@vscode/debugadapter/lib/logger';
 
 export class AmalgamatorClient extends DebugClient {
     private clientExited = false;
-    private ChildDapIndex = 0;
     // There should not be any error output from a client - any error is probably fatal.
     private errorOutput = '';
-    public getChildDapIndex() {
-        return this.ChildDapIndex;
-    }
     public hasClientExited() {
         return this.clientExited;
     }

--- a/src/AmalgamatorClient.ts
+++ b/src/AmalgamatorClient.ts
@@ -15,9 +15,12 @@ import { logger } from '@vscode/debugadapter/lib/logger';
 
 export class AmalgamatorClient extends DebugClient {
     private clientExited = false;
+    private ChildDapIndex = 0;
     // There should not be any error output from a client - any error is probably fatal.
     private errorOutput = '';
-
+    public getChildDapIndex() {
+        return this.ChildDapIndex;
+    }
     public hasClientExited() {
         return this.clientExited;
     }

--- a/src/AmalgamatorClient.ts
+++ b/src/AmalgamatorClient.ts
@@ -70,9 +70,4 @@ export class AmalgamatorClient extends DebugClient {
             });
         }
     }
-    public disassembleRequest(
-        args: DebugProtocol.DisassembleArguments
-    ): Promise<DebugProtocol.DisassembleResponse> {
-        return this.send('disassemble', args);
-    }
 }

--- a/src/AmalgamatorClient.ts
+++ b/src/AmalgamatorClient.ts
@@ -17,6 +17,7 @@ export class AmalgamatorClient extends DebugClient {
     private clientExited = false;
     // There should not be any error output from a client - any error is probably fatal.
     private errorOutput = '';
+   
     public hasClientExited() {
         return this.clientExited;
     }

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -421,7 +421,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
                  *  the child dap to be handled.
                  * Note:
                  *  1. This should be updated after problems are resolved
-                 *  2. Limit of that solution is this can work incorrectly when child daps have same start addresses
+                 *  2. Limit of the solution is this can work incorrectly when child daps have same start addresses
                  *  or end addresses or the instructionPointerReference.
                  */
                 this.addressMap.set(
@@ -535,7 +535,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
                  * the child dap to be handled.
                  * Note:
                  * 1. This should be updated after problems are resolved
-                 * 2. Limit of that solution is that it can work incorrectly when child daps have the same start addresses
+                 * 2. Limit of the solution is that it can work incorrectly when child daps have the same start addresses
                  * or end addresses or the instructionPointerReference.
                  */
                 this.childDapIndex = this.addressMap.has(args.memoryReference)

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -408,6 +408,22 @@ export class AmalgamatorSession extends LoggingDebugSession {
         frames.forEach((frame) => {
             frame.id = this.frameHandles.create([childDap, frame.id]);
             if (frame.instructionPointerReference) {
+                /**
+                 * Here's a workaround for problems:
+                 *  1. VSCode assuming that the instructionPointerReference has the same format as DisassembledInstruction.address
+                 *  even though the spec doesn't say so.
+                 *  See the spec at https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+                 *  The problem has been reported at https://github.com/microsoft/vscode/issues/164875
+                 *  2. VSCode/debug adapter protocol does not support multiple memory spaces.
+                 *  The problem has been reported at https://github.com/microsoft/vscode/issues/164877
+                 * Solution:
+                 *  Based on elements: start addresses or end addresses or the instructionPointerReference to determine
+                 *  the child dap to be handled.
+                 * Note:
+                 *  1. This should be updated after problems are resolved
+                 *  2. Limit of that solution is this can work incorrectly when child daps have same start addresses
+                 *  or end addresses or the instructionPointerReference.
+                 */
                 this.addressMap.set(
                     frame.instructionPointerReference,
                     childIndex
@@ -506,6 +522,22 @@ export class AmalgamatorSession extends LoggingDebugSession {
                 instructions: [],
             };
             try {
+                /**
+                 * Here's a workaround for problems:
+                 * 1. VSCode assuming that the instructionPointerReference has the same format as DisassembledInstruction.address
+                 * even though the spec doesn't say so.
+                 * See the spec at https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+                 * The problem has been reported at https://github.com/microsoft/vscode/issues/164875
+                 * 2. VSCode/debug adapter protocol does not support multiple memory spaces.
+                 * The problem has been reported at https://github.com/microsoft/vscode/issues/164877
+                 * Solution:
+                 * Based on elements: start addresses or end addresses or the instructionPointerReference to determine
+                 * the child dap to be handled.
+                 * Note:
+                 * 1. This should be updated after problems are resolved
+                 * 2. Limit of that solution is that it can work incorrectly when child daps have the same start addresses
+                 * or end addresses or the instructionPointerReference.
+                 */
                 this.childDapIndex = this.addressMap.has(args.memoryReference)
                     ? this.addressMap.get(args.memoryReference)
                     : this.childDapIndex;

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -114,8 +114,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
         new Handles();
     protected variableHandles: Handles<[AmalgamatorClient, number]> =
         new Handles();
-    protected disassembleHandles: Handles<[AmalgamatorClient, string]> =
-        new Handles();
+
     constructor() {
         super();
         this.logger = logger;
@@ -461,6 +460,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
         response.body = variables.body;
         this.sendResponse(response);
     }
+
     protected async evaluateRequest(
         response: DebugProtocol.EvaluateResponse,
         args: DebugProtocol.EvaluateArguments

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -107,7 +107,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
     /* child processes XXX: A type that represents the union of the following datastructures? */
     protected childDaps: AmalgamatorClient[] = [];
     /**
-     * This is a map of the start/end addresses or the instructionPointerReference that client see -> child DAP index, child DAP addresses
+     * This is a map of the start/end addresses or the instructionPointerReference that client sees -> child DAP index, child DAP addresses
      */
     protected addressMap: Map<string, number> = new Map<string, number>();
     protected childDapNames: string[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,18 +219,12 @@
   dependencies:
     "@vscode/debugprotocol" "1.58.0-pre.0"
 
-"@vscode/debugadapter@^1.50.0":
-  version "1.51.1"
-  resolved "https://registry.yarnpkg.com/@vscode/debugadapter/-/debugadapter-1.51.1.tgz#3e359801ab0c75eea40b29932ddac6a8c0c4992e"
-  integrity sha512-oRzHenxK/5ZwqZr+tTq07pbuON61gV2mHBAg1MPDzzdj3oHs306OExFe9rrNw718pB9i8NfO2JJ1a7ah76dNxg==
+"@vscode/debugadapter@^1.58.0-pre.0":
+  version "1.58.0-pre.0"
+  resolved "https://registry.yarnpkg.com/@vscode/debugadapter/-/debugadapter-1.58.0-pre.0.tgz#02f2c9dcafd1795543fb70628f0eca949284e030"
+  integrity sha512-WkI7XIavvEsI7pl5w7ERQgqQnUvFyuoTkm9Lf9EGowYDeTpZMxwZqQJOIgVCJux1XFECsD5w70AioPEuDJ7nlA==
   dependencies:
-    "@vscode/debugprotocol" "1.51.0"
-    mkdirp "^1.0.4"
-
-"@vscode/debugprotocol@1.51.0":
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.51.0.tgz#1d28a8581f8ea74b8e2fd465d4448717589a0ae3"
-  integrity sha512-39ShbKzI+0r53haLZQVEhY4XhdMJVSqfcliaDFigQjqiWattno5Ex0jXq2WRHrAtPf+W5Un9/HtED0K3pAiqZg==
+    "@vscode/debugprotocol" "1.58.0-pre.0"
 
 "@vscode/debugprotocol@1.58.0-pre.0":
   version "1.58.0-pre.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,7 +212,7 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@vscode/debugadapter-testsupport@^1.50.0":
+"@vscode/debugadapter-testsupport@^1.58.0-pre.0":
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/@vscode/debugadapter-testsupport/-/debugadapter-testsupport-1.51.0.tgz#6311ef18bab254d6bbc2be583da9eec0b857d449"
   integrity sha512-dRrJaSjT+4ay8VinylRZycjc5F+LptI5e0EL5kN+8Ap2KsIYAWzOsAxP/2f4DGN8QvE8gaPw2khtMZLrQYR5rQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,11 +213,11 @@
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
 "@vscode/debugadapter-testsupport@^1.58.0-pre.0":
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/@vscode/debugadapter-testsupport/-/debugadapter-testsupport-1.51.0.tgz#6311ef18bab254d6bbc2be583da9eec0b857d449"
-  integrity sha512-dRrJaSjT+4ay8VinylRZycjc5F+LptI5e0EL5kN+8Ap2KsIYAWzOsAxP/2f4DGN8QvE8gaPw2khtMZLrQYR5rQ==
+  version "1.58.0-pre.0"
+  resolved "https://registry.yarnpkg.com/@vscode/debugadapter-testsupport/-/debugadapter-testsupport-1.58.0-pre.0.tgz#2393a2196709c0e6db2506915993c78f386c7ba0"
+  integrity sha512-9K51jt0OehduyTXt6o8/jnoYLUEgJU/cs0yO/yqKJUBEkbrecgd76fHlX/wn2ikl63CBJm2YDRASMhH3lUKx4g==
   dependencies:
-    "@vscode/debugprotocol" "1.51.0"
+    "@vscode/debugprotocol" "1.58.0-pre.0"
 
 "@vscode/debugadapter@^1.50.0":
   version "1.51.1"
@@ -231,6 +231,11 @@
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.51.0.tgz#1d28a8581f8ea74b8e2fd465d4448717589a0ae3"
   integrity sha512-39ShbKzI+0r53haLZQVEhY4XhdMJVSqfcliaDFigQjqiWattno5Ex0jXq2WRHrAtPf+W5Un9/HtED0K3pAiqZg==
+
+"@vscode/debugprotocol@1.58.0-pre.0":
+  version "1.58.0-pre.0"
+  resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.58.0-pre.0.tgz#53133d5d4f34f0f5d058bc4c4e5f6f088ec669d3"
+  integrity sha512-W09dIn7hZ7LbF7Ap/7AxdjRci4l9Q6WMrVxNdMg7rtSBMU9kYkVZbb7tJWYZVAica4xq8cdLn01HF1XHyyYrYA==
 
 acorn-jsx@^5.3.1:
   version "5.3.2"


### PR DESCRIPTION
When using multicore debugging using the CDT-amalgamator feature in the VS Code debug plugin. Disassembly view is not available for amalgamator debug launches. We need to support disassembly view for this case.

The eventual solution that was agreed on needed to workaround problems in VSCode:

1. VSCode assuming that the instructionPointerReference has the same format as DisassembledInstruction.address even though the spec doesn't say so. See the spec at https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame The problem has been reported at https://github.com/microsoft/vscode/issues/164875
2. VSCode/debug adapter protocol does not support multiple memory spaces. The problem has been reported at https://github.com/microsoft/vscode/issues/164877

Solution:

- Based on elements: start addresses or end addresses or the instructionPointerReference to determine the child dap to be handled.

Notes:

1. This should be updated after problems are resolved
2. Limit of the solution is this can work incorrectly when child daps have same start addresses or end addresses or the instructionPointerReference.