### PR TITLE
Update requirement to have "request": "attach"

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,22 @@
           "launch": {
             "required": [],
             "properties": {}
+          },
+          "attach": {
+            "required": [],
+            "properties": {}
           }
         },
         "initialConfigurations": [
           {
             "type": "amalgamator",
-            "request": "launch",
+            "request": {
+              "type": "string",
+              "enum": [
+                "launch",
+                "attach"
+              ]
+            },
             "name": "Amalgamator Example"
           }
         ],
@@ -84,7 +94,13 @@
             "description": "A new configuration for amalgamating multiple debug adapter launches.",
             "body": {
               "type": "amalgamator",
-              "request": "launch",
+              "request": {
+                "type": "string",
+                "enum": [
+                  "launch",
+                  "attach"
+                ]
+              },
               "name": "Amalgamator Example"
             }
           }

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -50,9 +50,16 @@ export interface ChildDapArguments {
     delay?: number;
 
     /**
+     * Specify launch or attach request to start debugging for children
+     */
+    request?: string;
+
+    /**
      * This is the request arguments (normally specified in the launch.json)
      */
-    arguments: DebugProtocol.LaunchRequestArguments;
+    arguments:
+        | DebugProtocol.LaunchRequestArguments
+        | DebugProtocol.AttachRequestArguments;
 }
 
 export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
@@ -172,7 +179,10 @@ export class AmalgamatorSession extends LoggingDebugSession {
         }
     }
 
-    protected async createChild(child: ChildDapArguments, index: number) {
+    protected async startAmalgamatorClient(
+        child: ChildDapArguments,
+        index: number
+    ) {
         logger.verbose(
             `creating debug adapter ${child.debugAdapterRuntime} ${child.debugAdapterExecutable}`
         );
@@ -235,7 +245,16 @@ export class AmalgamatorSession extends LoggingDebugSession {
 
         await dc.start();
         await dc.initializeRequest(this.initializeRequestArgs);
-        await dc.launchRequest(child.arguments);
+        return dc;
+    }
+
+    protected async createChild(child: ChildDapArguments, index: number) {
+        const dc = await this.startAmalgamatorClient(child, index);
+        if (child.request === 'attach') {
+            await dc.attachRequest(child.arguments);
+        } else {
+            await dc.launchRequest(child.arguments);
+        }
         return dc;
     }
 


### PR DESCRIPTION
We need to fix AmalgamatorSession.createChild so that it knows whether to launch or attach a request. Because AmalgamatorSession currently only supports launch request.