### PR TITLE
Add suspend all button and custom debug command

### DIFF
--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -721,7 +721,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
                     ) {
                         await childDap.pauseRequest({ threadId: childId });
                         this.sendEvent(
-                            new StoppedEvent('SIGINT', thread.id, false, false)
+                            new StoppedEvent('SIGINT', thread.id, true, false)
                         );
                     }
                 }


### PR DESCRIPTION
Adds a new suspend all button to the debug toolbar when the amalgamator is the active debug session and passes the new custom command to the amalgamator for suspend all: `cdt-amalgamator/suspendAll`