### PR TITLE
Resume all and Suspend all sessions incorrect for multicores device

### DIFF
--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -269,7 +269,6 @@ export class AmalgamatorSession extends LoggingDebugSession {
             const reason = e.body.reason;
             const intiatingThreadId = e.body.threadId;
 
-            await new Promise((res) => setTimeout(res, 5000));
             const threadMap = await this.getThreadMap();
             let stoppedDapIndex = -1;
             // First send the event for the stopped thread
@@ -722,12 +721,14 @@ export class AmalgamatorSession extends LoggingDebugSession {
                     const threadInfo = threadOfChildDap as ThreadInfo;
                     if (
                         threadInfo.running === false &&
+                        thread.name.includes(threadInfo.name) &&
                         command === 'cdt-amalgamator/resumeAll'
                     ) {
                         await childDap.continueRequest({ threadId: childId });
                         this.sendEvent(new ContinuedEvent(thread.id, false));
                     } else if (
                         threadInfo.running === true &&
+                        thread.name.includes(threadInfo.name) &&
                         command === 'cdt-amalgamator/suspendAll'
                     ) {
                         await childDap.pauseRequest({ threadId: childId });

--- a/src/AmalgamatorSession.ts
+++ b/src/AmalgamatorSession.ts
@@ -380,7 +380,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
         }
     }
     private threadMapInProcess:
-        | Promise<[Map<number, [number, number]>, DebugProtocol.Thread[]]>
+        | Promise<[Map<number, [number, number]>, ThreadInfo[]]>
         | undefined;
     protected async getThreadMap(): Promise<Map<number, [number, number]>> {
         return new Promise<Map<number, [number, number]>>(
@@ -392,7 +392,7 @@ export class AmalgamatorSession extends LoggingDebugSession {
         );
     }
     protected getThreadMapInternal(): Promise<
-        [Map<number, [number, number]>, DebugProtocol.Thread[]]
+        [Map<number, [number, number]>, ThreadInfo[]]
     > {
         if (this.threadMapInProcess === undefined) {
             return this.collectChildTheads();
@@ -401,10 +401,10 @@ export class AmalgamatorSession extends LoggingDebugSession {
     }
 
     private collectChildTheads(): Promise<
-        [Map<number, [number, number]>, DebugProtocol.Thread[]]
+        [Map<number, [number, number]>, ThreadInfo[]]
     > {
         this.threadMapInProcess = new Promise((resolve, _reject) => {
-            const threads: DebugProtocol.Thread[] = [];
+            const threads: ThreadInfo[] = [];
             Promise.all(this.childDaps.map((dc) => dc.threadsRequest())).then(
                 (responses) => {
                     const threadMap: Map<number, [number, number]> = new Map<
@@ -421,7 +421,11 @@ export class AmalgamatorSession extends LoggingDebugSession {
                                         ? this.childDapNames[i] + ': '
                                         : ''
                                 } ${t.name}`, // XXX: prefix name here with which child this came from? What about the id of the child?
-                            } as DebugProtocol.Thread);
+                                running:
+                                    'running' in t
+                                        ? (t as ThreadInfo).running
+                                        : undefined,
+                            } as ThreadInfo);
                             threadMap.set(clientId, [i, t.id]);
                             clientId++;
                         });
@@ -716,26 +720,20 @@ export class AmalgamatorSession extends LoggingDebugSession {
                     thread.id
                 );
                 const childDap = this.childDaps[childIndex];
-                const childResponse = await childDap.threadsRequest();
-                for (const threadOfChildDap of childResponse.body.threads) {
-                    const threadInfo = threadOfChildDap as ThreadInfo;
-                    if (
-                        threadInfo.running === false &&
-                        thread.name.includes(threadInfo.name) &&
-                        command === 'cdt-amalgamator/resumeAll'
-                    ) {
-                        await childDap.continueRequest({ threadId: childId });
-                        this.sendEvent(new ContinuedEvent(thread.id, false));
-                    } else if (
-                        threadInfo.running === true &&
-                        thread.name.includes(threadInfo.name) &&
-                        command === 'cdt-amalgamator/suspendAll'
-                    ) {
-                        await childDap.pauseRequest({ threadId: childId });
-                        this.sendEvent(
-                            new StoppedEvent('SIGINT', thread.id, true, false)
-                        );
-                    }
+                if (
+                    thread.running === false &&
+                    command === 'cdt-amalgamator/resumeAll'
+                ) {
+                    await childDap.continueRequest({ threadId: childId });
+                    this.sendEvent(new ContinuedEvent(thread.id, false));
+                } else if (
+                    thread.running === true &&
+                    command === 'cdt-amalgamator/suspendAll'
+                ) {
+                    await childDap.pauseRequest({ threadId: childId });
+                    this.sendEvent(
+                        new StoppedEvent('SIGINT', thread.id, true, false)
+                    );
                 }
             }
             this.sendResponse(response);


### PR DESCRIPTION
Summary:

When debugging for multicores devices with type amalgamator.

The Call Stack View had shown the status of Multicores incorrectly.
![1](https://github.com/eclipse-cdt-cloud/cdt-amalgamator/assets/104537989/d29c9ff8-8075-438d-a10e-a72214c3e26e)

And when we use the features (Resume All Session, Suspend All Session), they didn't work as expected.
All statuses of multicores shown in Call Stack View are shown incorrectly.

- Suspend All Sessions:
![2](https://github.com/eclipse-cdt-cloud/cdt-amalgamator/assets/104537989/c0c08529-06ab-4841-970a-f18cc18525b7)

- Resume All Sessions:
![3](https://github.com/eclipse-cdt-cloud/cdt-amalgamator/assets/104537989/3fd841b6-8e00-4312-befc-0995bacc26c3)

Besides, we can't continue or pause some cores to run debug after using Resume All and Suspend All Session.

**Analyze root cause:**

Currently, the startAmalgamatorClient() function in cdt-amalgamator's AmalgamatorSession.ts file had sent the stop event for the first thread as the stopped thread in each session, and that is incorrect for the multicores device because the first thread in the multicores device might not be the stopped thread. So, the Call Stack View has shown incorrectly the status of the multicores device.

About Resume All Session and Suspend All Session features, they didn't work correctly for the multicore device. With Suspend All Session feature, when using this feature, all threads of that device are stopped but the status (Pause, Running) in Call Stack View is not updated correctly due to the first initialization of the stopped threads of the multicores device. With Resume All Session feature, we had met the conflict when sending the continueRequest() for the stopped threads of that device repeated many times in customRequest() function so we can't resume all sessions for the multicore device.

**Solution:**

Updating the first initialization for the stopped threads of the multicores device to send the stopped event for the stopped threads in each session correctly.
Update the customRequest() function about Suspend All Session and Resume All Session features for the multicores device to suspend and resume successfully for all sessions.